### PR TITLE
iOS info.plist cofiguration fix

### DIFF
--- a/platform_ios.md
+++ b/platform_ios.md
@@ -25,6 +25,6 @@ public override void PerformFetch(UIApplication application, Action<UIBackground
 ```xml
 <key>UIBackgroundModes</key>
 <array>
-	<string>background-fetch</string>
+	<string>fetch</string>
 </array>
 ```


### PR DESCRIPTION
Hey!

I'm playing with this lib and when I was doing the iOS configuration I noticed that the job was not running an I was getting this on my console:
`"You've implemented -[<UIApplicationDelegate> application:performFetchWithCompletionHandler:], but you still need to add "fetch" to the list of your supported UIBackgroundModes in your Info.plist."`

I checked what was the value on Apple's documntation on this link[Here](https://developer.apple.com/library/archive/documentation/iPhone/Conceptual/iPhoneOSProgrammingGuide/BackgroundExecution/BackgroundExecution.html)

The correct value is fetch instead of background-fetch, so I took the liberty to make a change and submit it. 

Thank you for the hardwork building OSS!